### PR TITLE
Add GB locale to avoid crashing in the UK

### DIFF
--- a/App/src/week.js
+++ b/App/src/week.js
@@ -1,5 +1,6 @@
 export default {
   en_US: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'],
+  en_GB: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'],
   ja_JP: ['にち', 'げつ', 'か', 'すい', 'もく', 'きん', 'ど'],
   ko_KR: ['일', '월', '화', '수', '목', '금', '토'],
 };


### PR DESCRIPTION
Fixes a 2-year old issues where the app crashes in the UK.  Other locales may also be broken in the same way.

See comments in https://www.indiegogo.com/projects/pico-home-know-what-s-in-the-air-you-breathe/x/13481247#/comments

